### PR TITLE
feat(glibc_2_32): add polyfill for __libc_single_threaded, constant 0

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -22,7 +22,7 @@ build build/aarch64/polyfills.so: create_polyfill_so polyfill-glibc
   arch = aarch64
   target_glibc = 2.17
 build build/aarch64/polyfiller.o: cc src/aarch64/polyfiller.c | build/aarch64/assembled_gen.h
-build build/aarch64/assembled_gen.h: run build/aarch64/assembler src/aarch64/_init.s src/aarch64/atexit.s src/aarch64/c11_thread.s src/aarch64/fatal.s src/aarch64/glibc_2_18.s src/aarch64/glibc_2_25.s src/aarch64/glibc_2_26.s src/aarch64/glibc_2_30.s src/aarch64/glibc_2_31.s src/aarch64/glibc_2_34.s src/aarch64/glibc_2_36.s src/aarch64/glibc_2_38.s src/aarch64/stdbit.s src/aarch64/syscalls.s src/aarch64/syscalls_ac.s
+build build/aarch64/assembled_gen.h: run build/aarch64/assembler src/aarch64/_init.s src/aarch64/atexit.s src/aarch64/c11_thread.s src/aarch64/fatal.s src/aarch64/glibc_2_18.s src/aarch64/glibc_2_25.s src/aarch64/glibc_2_26.s src/aarch64/glibc_2_30.s src/aarch64/glibc_2_31.s src/aarch64/glibc_2_32.s src/aarch64/glibc_2_34.s src/aarch64/glibc_2_36.s src/aarch64/glibc_2_38.s src/aarch64/stdbit.s src/aarch64/syscalls.s src/aarch64/syscalls_ac.s
 build build/aarch64/assembler: link build/aarch64/assembler.o build/tokenise.o build/sht.o build/uuht.o build/common.o
 build build/aarch64/assembler.o: cc src/aarch64/assembler.c | build/aarch64/assembler_gen.h
 build build/aarch64/assembler_gen.h: run build/aarch64/build_assembler src/aarch64/insn_encoding.txt
@@ -33,7 +33,7 @@ build build/x86_64/polyfills.so: create_polyfill_so polyfill-glibc
   arch = x86_64
   target_glibc = 2.3.2
 build build/x86_64/polyfiller.o: cc src/x86_64/polyfiller.c | build/x86_64/assembled_gen.h
-build build/x86_64/assembled_gen.h: run build/x86_64/assembler src/x86_64/_init.s src/x86_64/atexit.s src/x86_64/c11_thread.s src/x86_64/fatal.s src/x86_64/glibc_2_6.s src/x86_64/glibc_2_7.s src/x86_64/glibc_2_15.s src/x86_64/glibc_2_16.s src/x86_64/glibc_2_18.s src/x86_64/glibc_2_25.s src/x86_64/glibc_2_26.s src/x86_64/glibc_2_30.s src/x86_64/glibc_2_31.s src/x86_64/glibc_2_34.s src/x86_64/glibc_2_36.s src/x86_64/glibc_2_38.s src/x86_64/posix_spawn.s src/x86_64/qsort.s src/x86_64/stdbit.s src/x86_64/syscalls.s src/x86_64/syscalls_ac.s
+build build/x86_64/assembled_gen.h: run build/x86_64/assembler src/x86_64/_init.s src/x86_64/atexit.s src/x86_64/c11_thread.s src/x86_64/fatal.s src/x86_64/glibc_2_6.s src/x86_64/glibc_2_7.s src/x86_64/glibc_2_15.s src/x86_64/glibc_2_16.s src/x86_64/glibc_2_18.s src/x86_64/glibc_2_25.s src/x86_64/glibc_2_26.s src/x86_64/glibc_2_30.s src/x86_64/glibc_2_31.s src/x86_64/glibc_2_32.s src/x86_64/glibc_2_34.s src/x86_64/glibc_2_36.s src/x86_64/glibc_2_38.s src/x86_64/posix_spawn.s src/x86_64/qsort.s src/x86_64/stdbit.s src/x86_64/syscalls.s src/x86_64/syscalls_ac.s
 build build/x86_64/assembler: link build/x86_64/assembler.o build/tokenise.o build/sht.o build/uuht.o build/common.o
 build build/x86_64/assembler.o: cc src/x86_64/assembler.c | build/x86_64/assembler_gen.h
 build build/x86_64/assembler_gen.h: run build/x86_64/build_assembler src/x86_64/insn_encoding.txt

--- a/src/aarch64/glibc_2_32.s
+++ b/src/aarch64/glibc_2_32.s
@@ -1,0 +1,3 @@
+public const variable __libc_single_threaded {
+  byte 0
+}

--- a/src/aarch64/renames.txt
+++ b/src/aarch64/renames.txt
@@ -772,7 +772,7 @@ totalordermagf64x@GLIBC_2.31 polyfill::totalordermag_f128ptr
 totalordermagl@GLIBC_2.31 polyfill::totalordermag_f128ptr
 
 // GLIBC_2.32
-// TODO __libc_single_threaded@GLIBC_2.32
+__libc_single_threaded@GLIBC_2.32 polyfill::__libc_single_threaded
 // TODO pthread_attr_getsigmask_np@GLIBC_2.32
 // TODO pthread_attr_setsigmask_np@GLIBC_2.32
 pthread_attr_setaffinity_np@GLIBC_2.32 libpthread.so.0::pthread_attr_setaffinity_np@GLIBC_2.17

--- a/src/x86_64/glibc_2_32.s
+++ b/src/x86_64/glibc_2_32.s
@@ -1,0 +1,3 @@
+public const variable __libc_single_threaded {
+  byte 0
+}

--- a/src/x86_64/renames.txt
+++ b/src/x86_64/renames.txt
@@ -1106,7 +1106,7 @@ totalordermagf64x@GLIBC_2.31 polyfill::totalordermag_f80ptr
 totalordermagl@GLIBC_2.31 polyfill::totalordermag_f80ptr
 
 // GLIBC_2.32
-// TODO __libc_single_threaded@GLIBC_2.32
+__libc_single_threaded@GLIBC_2.32 polyfill::__libc_single_threaded
 // TODO pthread_attr_getsigmask_np@GLIBC_2.32
 // TODO pthread_attr_setsigmask_np@GLIBC_2.32
 pthread_attr_setaffinity_np@GLIBC_2.32 libpthread.so.0::pthread_attr_setaffinity_np@GLIBC_2.3.4


### PR DESCRIPTION
C.f. https://github.com/corsix/polyfill-glibc/issues/12

https://www.gnu.org/software/libc/manual/html_node/Single_002dThreaded.html 
> Variable: char __libc_single_threaded
> This variable is non-zero if the current process is definitely single-threaded. If it is zero, the process may be multi-threaded, or the GNU C Library cannot determine at this point of the program execution whether the process is single-threaded or not. 

For now this is a constant zero.

A future enhancement to do this better, would be to detect if any functions from pthread are called, or if libpthread itself is linked dynamically to the binary -- then set this value to nonzero if so.
